### PR TITLE
Gesture input demo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.wav filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.wav filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/Inkscape/gesture-input-background.svg
+++ b/Inkscape/gesture-input-background.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e8e4d0329fadbcea9ff74989bcb5ece5e45b6f6dce1e2bf494a617f6da480b0
+size 1833

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Prefabs/Gesture target.prefab
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Prefabs/Gesture target.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6670290324605476408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2474456230020369730}
+  - component: {fileID: 7768796963372939441}
+  - component: {fileID: 9183276638833653763}
+  m_Layer: 5
+  m_Name: Gesture target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2474456230020369730
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6670290324605476408}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7768796963372939441
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6670290324605476408}
+  m_CullTransparentMesh: 1
+--- !u!114 &9183276638833653763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6670290324605476408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.3803922, b: 0.55656844, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Prefabs/Gesture target.prefab
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Prefabs/Gesture target.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 50, y: 50}
+  m_SizeDelta: {x: 75, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7768796963372939441
 CanvasRenderer:
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: 6e7412726e4d80745af5e68afc8a55d3, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Prefabs/Gesture target.prefab.meta
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Prefabs/Gesture target.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 067e04c1d52a94caaa09282019356dde
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
@@ -208,7 +208,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 77583356}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 148984732099543ae97aef1368f4c78a, type: 3}
+  m_Script: {fileID: 11500000, guid: 535db31684ca4417fa2fde3b8ebb3d27, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   displaySizePx: 500
@@ -423,10 +423,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 711861685}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 75852fb068e694387afff9dfbcfd2415, type: 3}
+  m_Script: {fileID: 11500000, guid: b168fbb13a9fd4015a345fc56aeaf6a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gestureTargetPrefab: {fileID: 6670290324605476408, guid: ab34808a0ae104053b07914673b6d90a, type: 3}
+  gestureTargetPrefab: {fileID: 6670290324605476408, guid: 067e04c1d52a94caaa09282019356dde, type: 3}
   inputBackground: {fileID: 2095460243}
   inputCursor: {fileID: 77583356}
   targetTolerance: 50

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
@@ -181,7 +181,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: 6e7412726e4d80745af5e68afc8a55d3, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -388,6 +388,7 @@ GameObject:
   m_Component:
   - component: {fileID: 711861686}
   - component: {fileID: 711861687}
+  - component: {fileID: 711861688}
   m_Layer: 5
   m_Name: Gesture manager
   m_TagString: Untagged
@@ -430,6 +431,102 @@ MonoBehaviour:
   inputBackground: {fileID: 2095460243}
   inputCursor: {fileID: 77583356}
   targetTolerance: 50
+--- !u!82 &711861688
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 711861685}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: c9a79c2ab8a326942a1b23c008653024, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -572,7 +669,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: 6e7412726e4d80745af5e68afc8a55d3, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
@@ -211,7 +211,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 535db31684ca4417fa2fde3b8ebb3d27, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  displaySizePx: 500
+  inputBackground: {fileID: 2095460243}
 --- !u!1 &110442141
 GameObject:
   m_ObjectHideFlags: 0

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity
@@ -1,0 +1,592 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.20959418, g: 0.2340691, b: 0.2830189, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &77583356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 77583357}
+  - component: {fileID: 77583359}
+  - component: {fileID: 77583358}
+  - component: {fileID: 77583360}
+  m_Layer: 5
+  m_Name: Input cursor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &77583357
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77583356}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2095460244}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &77583358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77583356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3820755, g: 0.38208905, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &77583359
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77583356}
+  m_CullTransparentMesh: 1
+--- !u!114 &77583360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77583356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 148984732099543ae97aef1368f4c78a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  displaySizePx: 500
+--- !u!1 &110442141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 110442144}
+  - component: {fileID: 110442143}
+  - component: {fileID: 110442142}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &110442142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110442141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &110442143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110442141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &110442144
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110442141}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &456138650
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 456138654}
+  - component: {fileID: 456138653}
+  - component: {fileID: 456138652}
+  - component: {fileID: 456138651}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &456138651
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456138650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &456138652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456138650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &456138653
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456138650}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &456138654
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456138650}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 2095460244}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &711861685
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 711861686}
+  - component: {fileID: 711861687}
+  m_Layer: 5
+  m_Name: Gesture manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &711861686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 711861685}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2095460244}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &711861687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 711861685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75852fb068e694387afff9dfbcfd2415, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gestureTargetPrefab: {fileID: 6670290324605476408, guid: ab34808a0ae104053b07914673b6d90a, type: 3}
+  inputBackground: {fileID: 2095460243}
+  inputCursor: {fileID: 77583356}
+  targetTolerance: 50
+--- !u!1 &963194225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963194228}
+  - component: {fileID: 963194227}
+  - component: {fileID: 963194226}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963194226
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+--- !u!20 &963194227
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &963194228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2095460243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2095460244}
+  - component: {fileID: 2095460246}
+  - component: {fileID: 2095460245}
+  m_Layer: 5
+  m_Name: Input background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2095460244
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095460243}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 77583357}
+  - {fileID: 711861686}
+  m_Father: {fileID: 456138654}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 500, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2095460245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095460243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2095460246
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095460243}
+  m_CullTransparentMesh: 1

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity.meta
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scenes/GestureTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: deb4a204b52b54b489ccd2f1c12a2b5c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+
+public class GestureManager : MonoBehaviour
+{
+    public GameObject gestureTargetPrefab;
+    public GameObject inputBackground;
+    public GameObject inputCursor;
+    public float targetTolerance = 5;
+
+    private int currentTargetIndex = 0;
+    private Vector2[] targetPositions;
+    private List<GameObject> gestureTargets;
+    private RectTransform cursorTransform;
+
+    static Color yellowColor = Color.yellow;
+    static Color pinkColor = new Color(1f, 0.38f, 0.56f, 1f);
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        cursorTransform = inputCursor.GetComponent<RectTransform>();
+
+        targetPositions = new Vector2[]
+        {
+            new Vector2(-250, 0),
+            new Vector2(-250, -250),
+            new Vector2(0, -250),
+            new Vector2(250, -250),
+            new Vector2(250, 0)
+        };
+
+        gestureTargets = new List<GameObject>();
+        foreach (Vector2 targetPosition in targetPositions)
+        {
+            GameObject gestureTarget = Instantiate(
+                gestureTargetPrefab, inputBackground.transform
+            );
+            gestureTargets.Add(gestureTarget);
+
+            RectTransform rectTransform = gestureTarget.GetComponent<RectTransform>();
+            rectTransform.anchoredPosition = new Vector2(targetPosition.x, targetPosition.y);
+        }
+
+        SetTargetColors();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        Vector2 nextTargetPosition = targetPositions[currentTargetIndex];
+        Vector2 inputCursorPosition = cursorTransform.anchoredPosition;
+
+        float targetDistance = (nextTargetPosition - inputCursorPosition).magnitude;
+        bool isCursorOnTarget = targetDistance < targetTolerance;
+        if (isCursorOnTarget)
+        {
+            currentTargetIndex = (currentTargetIndex + 1) % targetPositions.Length;
+        }
+        SetTargetColors();
+    }
+
+    void SetTargetColors()
+    {
+        for (int targetIndex = 0; targetIndex < gestureTargets.Count; targetIndex++)
+        {
+            Color color;
+            bool isCurrentTarget = targetIndex == currentTargetIndex;
+            if (isCurrentTarget)
+            {
+                color = pinkColor;
+            }
+            else
+            {
+                color = yellowColor;
+            }
+
+            GameObject gestureTarget = gestureTargets[targetIndex];
+            Image image = gestureTarget.GetComponent<Image>();
+            image.color = color;   
+        }
+        
+    }
+}

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
@@ -18,7 +18,7 @@ public class GestureManager : MonoBehaviour
     private RectTransform cursorTransform;
     private AudioSource clickSound;
 
-    static Color yellowColor = Color.yellow;
+    static Color yellowColor = new Color(0.85f, 0.8f, 0f, 1f);
     static Color pinkColor = new Color(1f, 0.38f, 0.56f, 1f);
 
     void Start()

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -24,13 +25,16 @@ public class GestureManager : MonoBehaviour
     {
         cursorTransform = inputCursor.GetComponent<RectTransform>();
 
+        float targetRadius = 250;
+        Vector2 targetCorner = targetRadius * Vector2.ClampMagnitude(new Vector2(1, 1), 1.0f);
+
         targetPositions = new Vector2[]
         {
-            new Vector2(-250, 0),
-            new Vector2(-250, -250),
-            new Vector2(0, -250),
-            new Vector2(250, -250),
-            new Vector2(250, 0)
+            new Vector2(-targetRadius, 0),
+            new Vector2(-targetCorner.x, -targetCorner.y),
+            new Vector2(0, -targetRadius),
+            new Vector2(targetCorner.x, -targetCorner.y),
+            new Vector2(targetRadius, 0)
         };
 
         gestureTargets = new List<GameObject>();

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
@@ -25,7 +25,8 @@ public class GestureManager : MonoBehaviour
     {
         cursorTransform = inputCursor.GetComponent<RectTransform>();
 
-        float targetRadius = 250;
+        float inputBackgroundWidth = inputBackground.GetComponent<RectTransform>().sizeDelta.x;
+        float targetRadius = inputBackgroundWidth / 2;
         Vector2 targetCorner = targetRadius * Vector2.ClampMagnitude(new Vector2(1, 1), 1.0f);
 
         targetPositions = new Vector2[]

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs
@@ -16,15 +16,20 @@ public class GestureManager : MonoBehaviour
     private Vector2[] targetPositions;
     private List<GameObject> gestureTargets;
     private RectTransform cursorTransform;
+    private AudioSource clickSound;
 
     static Color yellowColor = Color.yellow;
     static Color pinkColor = new Color(1f, 0.38f, 0.56f, 1f);
 
-    // Start is called before the first frame update
     void Start()
     {
         cursorTransform = inputCursor.GetComponent<RectTransform>();
+        clickSound = GetComponent<AudioSource>();
+        InitializeTargets();
+    }
 
+    private void InitializeTargets()
+    {
         float inputBackgroundWidth = inputBackground.GetComponent<RectTransform>().sizeDelta.x;
         float targetRadius = inputBackgroundWidth / 2;
         Vector2 targetCorner = targetRadius * Vector2.ClampMagnitude(new Vector2(1, 1), 1.0f);
@@ -53,7 +58,7 @@ public class GestureManager : MonoBehaviour
         SetTargetColors();
     }
 
-    // Update is called once per frame
+
     void Update()
     {
         Vector2 nextTargetPosition = targetPositions[currentTargetIndex];
@@ -64,6 +69,7 @@ public class GestureManager : MonoBehaviour
         if (isCursorOnTarget)
         {
             currentTargetIndex = (currentTargetIndex + 1) % targetPositions.Length;
+            clickSound.Play();
         }
         SetTargetColors();
     }

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs.meta
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/GestureManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b168fbb13a9fd4015a345fc56aeaf6a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MoveInputCursor : MonoBehaviour
+{
+    public int displaySizePx = 500;
+
+    RectTransform rectTransform;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        rectTransform = GetComponent<RectTransform>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        int halfDisplaySizePx = displaySizePx / 2;
+
+        float horizontalInput = Input.GetAxis("Horizontal");
+        float verticalInput = Input.GetAxis("Vertical");
+
+        Vector2 position = new Vector2(
+            horizontalInput * halfDisplaySizePx,
+            verticalInput * halfDisplaySizePx
+        );
+
+        rectTransform.anchoredPosition = position;
+    }
+}

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
@@ -4,28 +4,30 @@ using UnityEngine;
 
 public class MoveInputCursor : MonoBehaviour
 {
-    public int displaySizePx = 500;
-
+    public GameObject inputBackground;
+    
+    float targetRadius;
     RectTransform rectTransform;
 
     // Start is called before the first frame update
     void Start()
     {
         rectTransform = GetComponent<RectTransform>();
+
+        float inputBackgroundWidth = inputBackground.GetComponent<RectTransform>().sizeDelta.x;
+        targetRadius = inputBackgroundWidth / 2;
     }
 
     // Update is called once per frame
     void Update()
     {
-        int halfDisplaySizePx = displaySizePx / 2;
-
         float horizontalInput = Input.GetAxis("Horizontal");
         float verticalInput = Input.GetAxis("Vertical");
 
         Vector2 inputCoord = new Vector2(horizontalInput, verticalInput);
         Vector2 clampedInputCoord = Vector2.ClampMagnitude(inputCoord, 1.0f);
 
-        Vector2 inputPosition = clampedInputCoord * halfDisplaySizePx;
+        Vector2 inputPosition = clampedInputCoord * targetRadius;
         rectTransform.anchoredPosition = inputPosition;
     }
 }

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
@@ -22,11 +22,10 @@ public class MoveInputCursor : MonoBehaviour
         float horizontalInput = Input.GetAxis("Horizontal");
         float verticalInput = Input.GetAxis("Vertical");
 
-        Vector2 position = new Vector2(
-            horizontalInput * halfDisplaySizePx,
-            verticalInput * halfDisplaySizePx
-        );
+        Vector2 inputCoord = new Vector2(horizontalInput, verticalInput);
+        Vector2 clampedInputCoord = Vector2.ClampMagnitude(inputCoord, 1.0f);
 
-        rectTransform.anchoredPosition = position;
+        Vector2 inputPosition = clampedInputCoord * halfDisplaySizePx;
+        rectTransform.anchoredPosition = inputPosition;
     }
 }

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs
@@ -9,7 +9,6 @@ public class MoveInputCursor : MonoBehaviour
     float targetRadius;
     RectTransform rectTransform;
 
-    // Start is called before the first frame update
     void Start()
     {
         rectTransform = GetComponent<RectTransform>();
@@ -18,7 +17,6 @@ public class MoveInputCursor : MonoBehaviour
         targetRadius = inputBackgroundWidth / 2;
     }
 
-    // Update is called once per frame
     void Update()
     {
         float horizontalInput = Input.GetAxis("Horizontal");

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs.meta
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Scripts/MoveInputCursor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 535db31684ca4417fa2fde3b8ebb3d27
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Sounds/270145__theriavirra__drumsticks-stagg-maple-5an-soft-no3.wav
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Sounds/270145__theriavirra__drumsticks-stagg-maple-5an-soft-no3.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea45bfdea17e6c3cd02cca3be63f2daeb765983708dfe1e4791ad63a00fe211d
+size 43364

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Sounds/270145__theriavirra__drumsticks-stagg-maple-5an-soft-no3.wav.meta
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Sounds/270145__theriavirra__drumsticks-stagg-maple-5an-soft-no3.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: c9a79c2ab8a326942a1b23c008653024
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Textures/gesture-input-background.png
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Textures/gesture-input-background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7843638f23a4d89fd6f07a52da1d3103380b3b61a9746eb8feba83a2ab77cde5
+size 10997

--- a/tome-quest-game-files-Unity/tome-quest/Assets/Textures/gesture-input-background.png.meta
+++ b/tome-quest-game-files-Unity/tome-quest/Assets/Textures/gesture-input-background.png.meta
@@ -1,0 +1,108 @@
+fileFormatVersion: 2
+guid: 6e7412726e4d80745af5e68afc8a55d3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tome-quest-game-files-Unity/tome-quest/ProjectSettings/InputManager.asset
+++ b/tome-quest-game-files-Unity/tome-quest/ProjectSettings/InputManager.asset
@@ -13,9 +13,9 @@ InputManager:
     positiveButton: right
     altNegativeButton: a
     altPositiveButton: d
-    gravity: 3
+    gravity: 10
     dead: 0.001
-    sensitivity: 3
+    sensitivity: 10
     snap: 1
     invert: 0
     type: 0
@@ -29,9 +29,9 @@ InputManager:
     positiveButton: up
     altNegativeButton: s
     altPositiveButton: w
-    gravity: 3
+    gravity: 10
     dead: 0.001
-    sensitivity: 3
+    sensitivity: 10
     snap: 1
     invert: 0
     type: 0


### PR DESCRIPTION
Adds a scene that demos gesture input capability. 

When the scene starts, a number of gesture "targets" are generated. A cursor can be moved with the horizontal and vertical axes. When the cursor gets to the next active target, shown in yellow, a click sound plays and another target is selected as the active one. With this approach, we can have an arbitrary path of targets that the user has to input, and give them a set amount of time to complete the gesture in.